### PR TITLE
Add 2-bit support to 36h11

### DIFF
--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -282,6 +282,11 @@ class Detector(object):
             self.tag_families['tag36h11'] = self.libc.tag36h11_create()
             self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
                                                         self.tag_families['tag36h11'], self.params['max_hamming'])
+        elif 'tag36h11b2' in self.params['families']:
+            self.libc.tag36h11b2_create.restype = ctypes.POINTER(_ApriltagFamily)
+            self.tag_families['tag36h11b2'] = self.libc.tag36h11b2_create()
+            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
+                                                        self.tag_families['tag36h11b2'], self.params['max_hamming'])
         elif 'tagCircle21h7' in self.params['families']:
             self.libc.tagCircle21h7_create.restype = ctypes.POINTER(_ApriltagFamily)
             self.tag_families['tagCircle21h7'] = self.libc.tagCircle21h7_create()
@@ -335,6 +340,9 @@ class Detector(object):
                 elif 'tag36h11' == family:
                     self.libc.tag36h11_destroy.restype = None
                     self.libc.tag36h11_destroy(tf)
+                elif 'tag36h11b2' == family:
+                    self.libc.tag36h11b2_destroy.restype = None
+                    self.libc.tag36h11b2_destroy(tf)
                 elif 'tagCircle21h7' == family:
                     self.libc.tagCircle21h7_destroy.restype = None
                     self.libc.tagCircle21h7_destroy(tf)


### PR DESCRIPTION
Add support for 2-bit April tags for the 36h11 family.

The new family name is `tag36h11b2`.